### PR TITLE
Print filenames of batch-generated files

### DIFF
--- a/pfscf/cmd/cmdBatch.go
+++ b/pfscf/cmd/cmdBatch.go
@@ -130,6 +130,7 @@ func executeBatchFill(cmd *cobra.Command, cmdArgs []string) {
 		baseOutfile := fmt.Sprintf("Chronicle_Player_%d.pdf", playerNumber)
 		outfile := filepath.Join(outDir, baseOutfile)
 
+		fmt.Printf("Creating file %v\n", outfile)
 		err = pdf.Fill(cmdLineArgStore, cTmpl, outfile)
 		utils.ExitOnError(err, "Error when filling out chronicle for player %d", playerNumber)
 	}


### PR DESCRIPTION
```
$ ./pfscf b f pfs2.s1-06 mySession.csv chronicles/s1-22.pdf testOut
Creating file testOut\Chronicle_Player_1.pdf
Creating file testOut\Chronicle_Player_2.pdf
Creating file testOut\Chronicle_Player_3.pdf
Creating file testOut\Chronicle_Player_4.pdf
Creating file testOut\Chronicle_Player_5.pdf
Creating file testOut\Chronicle_Player_6.pdf
Creating file testOut\Chronicle_Player_7.pdf
```