### PR TITLE
Initial draft of PFS Season 2 layout, based on bounties 1 & 2

### DIFF
--- a/pfscf/templates/pfs2/bounties/b01.yml
+++ b/pfscf/templates/pfs2/bounties/b01.yml
@@ -1,0 +1,3 @@
+id: pfs2.b01
+description: "Bounty #1: The Whitefang Wyrm"
+inherit: pfs2.bounties

--- a/pfscf/templates/pfs2/bounties/b02.yml
+++ b/pfscf/templates/pfs2/bounties/b02.yml
@@ -1,0 +1,3 @@
+id: pfs2.b02
+description: "Bounty #2: The Blood of the Beautiful"
+inherit: pfs2.bounties

--- a/pfscf/templates/pfs2/bounties/bounties.yml
+++ b/pfscf/templates/pfs2/bounties/bounties.yml
@@ -1,0 +1,3 @@
+id: pfs2.bounties
+description: PFS2 Bounties
+inherit: pfs2.layout2

--- a/pfscf/templates/pfs2/layout2.yml
+++ b/pfscf/templates/pfs2/layout2.yml
@@ -1,0 +1,667 @@
+id: pfs2.layout2
+description: "PFS2 Chronicle Sheet Format v2: Used only in Season 02"
+inherit: pfs2
+flags:
+  - hidden
+
+aspectratio: 603:783 # dimensions of chronicle page in original pdf
+
+parameters:
+  "Player Info":
+    player:
+      type: text
+      description: Player name
+      example: Bob
+
+    char:
+      type: text
+      description: Players character name
+      example: Stormageddon
+
+    societyid:
+      type: societyid
+      description: Pathfinder Society ID
+      example: 123456-2001
+
+    chronicle_nr:
+      type: text
+      description: Character chronicle number
+      example: 5
+
+  "Factions":
+    fac1_name:
+      type: text
+      description: "Faction 1: Name"
+      example: Grand Archive
+
+    fac1_rep_gained:
+      type: text
+      description: "Faction 1: Gained reputation points"
+      example: 4
+
+    fac1_rep_total:
+      type: text
+      description: "Faction 1: Total reputation points"
+      example: 16
+
+    fac2_name:
+      type: text
+      description: "Faction 2: Name"
+      example: "Envoys' Alliance"
+
+    fac2_rep_gained:
+      type: text
+      description: "Faction 2: Gained reputation points"
+      example: 4
+
+    fac2_rep_total:
+      type: text
+      description: "Faction 2: Total reputation points"
+      example: 12
+
+    fac3_name:
+      type: text
+      description: "Faction 3: Name"
+      example: Horizon Hunters
+
+    fac3_rep_gained:
+      type: text
+      description: "Faction 3: Gained reputation points"
+      example: 4
+
+    fac3_rep_total:
+      type: text
+      description: "Faction 3: Total reputation points"
+      example: 8
+
+  "Boons":
+    strikeout_boons:
+      type: choice
+      description: "Boons that should be striked out"
+      choices: [1, 2, 3]
+
+  "Rewards":
+    tier:
+      type: choice
+      description: "Players' tier"
+      choices: [low, high]
+
+    starting_xp:
+      type: text
+      description: Starting XP
+      example: 12
+
+    xp:
+      type: text
+      description: XP Gained
+      example: 4
+
+    final_xp:
+      type: text
+      description: Final XP
+      example: 16
+
+    starting_gp:
+      type: text
+      description: Starting GP
+      example: 23gp 4sp
+
+    gp:
+      type: text
+      description: GP Gained
+      example: 4gp 2sp
+
+    items_sold:
+      type: text
+      description: Items sold
+      example: 2gp
+
+    gp_spent:
+      type: text
+      description: GP Spent
+      example: 17sp
+
+    total_gp:
+      type: text
+      description: Total GP
+      example: 27gp 9sp 8cp
+
+  "Items Sold / Conditions Gained":
+    list_items_sold:
+      type: multiline
+      description: "Items Sold / Conditions Gained"
+      example: "Rusty armor, smells a little bit"
+      lines: 5
+    list_items_sold_price:
+      type: multiline
+      description: "Price for sold items"
+      example: "3cp"
+      lines: 5
+    items_sold_total_value:
+      type: text
+      description: "Total value of items sold"
+      example: "21cp"
+
+  "Items Bought / Conditions Cleared":
+    list_items_bought:
+      type: multiline
+      description: "Items Bought / Conditions Cleared"
+      example: "Shiny armor, only used once"
+      lines: 5
+    list_items_bought_price:
+      type: multiline
+      description: "Price for bought items"
+      example: "2gp"
+      lines: 5
+    items_bought_total_cost:
+      type: text
+      description: "Total cost of items bought"
+      example: "14gp"
+
+  "Notes":
+    notes:
+      type: multiline
+      description: "Notes on the chronicle sheet"
+      example: "Player was caught stealing a purse"
+      lines: 6
+
+  "Downtime":
+    downtime:
+      type: multiline
+      description: "Downtime Activities"
+      example: "All work and no play makes Jack a dull boy"
+      lines: 6
+
+  "Event Info":
+    event:
+      type: text
+      description: Event name
+      example: PaizoCon
+
+    eventcode:
+      type: text
+      description: Event code
+      example: 1234
+
+    date:
+      type: text
+      description: The date on which the game session took place
+      example: 27.06.2020
+
+    gm:
+      type: text
+      description: Gamemasters name
+      example: J. Doe
+
+    gmid:
+      type: text
+      description: Gamemasters PFS ID
+      example: 654321
+
+canvas:
+  page:
+    x:    0.0
+    y:    0.0
+    x2: 100.0
+    y2: 100.0
+
+  main:
+    # this should be a canvas matching the "main" content box,
+    # only excluding the title, chronicle nr and herolab code.
+    # Having this allows an easy visual check on whether the
+    # page is aligned or has extra margins
+    parent: page
+    x:   6.20
+    y:  11.40
+    x2: 94.00
+    y2: 95.40
+
+  rightbar:
+    parent: main
+    x:   82.2
+    y:  50.25
+    x2: 100.0
+    y2: 94.45
+
+  boon1.1:
+    # inactive per default, should be adapted when inheriting this template
+    parent: main
+    x:   0.5
+    y:   0.0
+    x2: 79.5
+    y2:  0.0
+
+  boon1.2:
+    # inactive per default, should be adapted when inheriting this template
+    parent: main
+    x:   0.5
+    y:   0.0
+    x2: 79.5
+    y2:  0.0
+
+  boon2.1:
+    # inactive per default, should be adapted when inheriting this template
+    parent: main
+    x:   0.5
+    y:   0.0
+    x2: 79.5
+    y2:  0.0
+
+  boon2.2:
+    # inactive per default, should be adapted when inheriting this template
+    parent: main
+    x:   0.5
+    y:   0.0
+    x2: 79.5
+    y2:  0.0
+
+  boon3.1:
+    # inactive per default, should be adapted when inheriting this template
+    parent: main
+    x:   0.5
+    y:   0.0
+    x2: 79.5
+    y2:  0.0
+
+  boon3.2:
+    # inactive per default, should be adapted when inheriting this template
+    parent: main
+    x:   0.5
+    y:   0.0
+    x2: 79.5
+    y2:  0.0
+
+  middlebox:
+    parent: main
+    x:   2.3
+    y: 50.25
+    x2: 79.8
+    y2: 82.9
+
+  items_low:
+    parent: middlebox
+    x:   0.0
+    y:   0.0
+    x2: 38.2
+    y2: 49.9
+
+  items_high:
+    parent: middlebox
+    x:    0.0
+    y:   50.8
+    x2:  38.2
+    y2: 100.0
+
+  items_sold:
+    parent: middlebox
+    x:   38.4
+    y:    0.0
+    x2: 100.0
+    y2:  49.9
+
+  items_bought:
+    parent: middlebox
+    x:   38.4
+    y:   50.1
+    x2: 100.0
+    y2: 100.0
+
+  commentbox:
+    parent: main
+    x:   0.4
+    y:  84.8
+    x2: 79.5
+    y2: 94.6
+
+presets:
+  defaultfont:
+    font: Helvetica
+    fontsize: 14
+
+  playerinfo:
+    presets: [defaultfont]
+    canvas: main
+    y:  5.5
+    align: CB
+
+  rightbar:
+    presets: [defaultfont]
+    canvas: rightbar
+    x:    0.0
+    x2: 100.0
+    align: CM
+
+  eventinfo:
+    presets: [defaultfont]
+    canvas: main
+    y:  98.0
+    align: CB
+
+  factions:
+    presets: [defaultfont]
+    canvas: main
+    fontsize: 8
+
+  faccol_name:
+    presets: [factions]
+    x:  74.4
+    x2: 85.5
+    align: CB
+
+  faccol_rep_gained:
+    presets: [factions]
+    x:  93.1
+    x2: 96.2
+    align: CB
+
+  faccol_rep_total:
+    presets: [factions]
+    x:  96.3
+    x2: 99.3
+    align: CB
+
+  facline1:
+    presets: [factions]
+    y:  2.85
+
+  facline2:
+    presets: [factions]
+    y:  5.95
+
+  facline3:
+    presets: [factions]
+    y:  9.0
+
+  greyout:
+    color: white
+    transparency: 0.3
+
+  max_area:
+    x: 0.0
+    y: 0.0
+    x2: 100.0
+    y2: 100.0
+
+  strikeout_boon:
+    presets: [greyout, max_area]
+
+  checkbox:
+    value: "X"
+    fontsize: 8
+    font: Helvetica
+    align: CM
+
+  commentbox:
+    presets: [defaultfont, max_area]
+    canvas: commentbox
+    align: LM
+    lines: 6
+
+  items_purchased_left_col:
+    presets: [defaultfont]
+    x:   3.0
+    x2: 69.5
+    align: LM
+
+  items_purchased_right_col:
+    presets: [defaultfont]
+    x:  73.0
+    x2: 97.0
+    align: CM
+
+  items_sold_line:
+    presets: [defaultfont]
+    canvas: items_sold
+    lines: 5
+    y: 19.0
+    y2: 74.4
+
+  items_bought_line:
+    presets: [defaultfont]
+    canvas: items_bought
+    lines: 5
+    y: 13.8
+    y2: 69.4
+
+content:
+  - value: param:player
+    type: text
+    presets: [playerinfo]
+    x:   0.8
+    x2: 19.7
+
+  - value: param:char
+    type: text
+    presets: [playerinfo]
+    x:  24.5
+    x2: 43.9
+
+  - type: trigger
+    trigger: param:societyid
+    content:
+      - type: rectangle
+        presets: [playerinfo]
+        color: white
+        x:  57.5
+        y:   3.4
+        x2: 60.5
+        y2:  5.2
+      - value: param:societyid.player
+        type: text
+        presets: [playerinfo]
+        x:  45.1
+        x2: 57.6
+        align: RB
+      - value: "-"
+        type: text
+        presets: [playerinfo]
+        x:  57.6
+        x2: 59.5
+        align: CB
+      - value: param:societyid.char
+        type: text
+        presets: [playerinfo]
+        x:  59.5
+        x2: 67.8
+        align: LB
+
+  - value: param:chronicle_nr
+    type: text
+    presets: [defaultfont]
+    canvas: page
+    x:  80.0
+    y:   4.6
+    x2: 93.8
+    y2:  6.7
+    align: CM
+
+  - value: param:starting_xp
+    type: text
+    presets: [rightbar]
+    y:  0.1
+    y2: 8.2
+
+  - value: param:xp
+    type: text
+    presets: [rightbar]
+    y:  12.4
+    y2: 20.6
+
+  - value: param:final_xp
+    type: text
+    presets: [rightbar]
+    y:  24.8
+    y2: 33.2
+
+  - value: param:starting_gp
+    type: text
+    presets: [rightbar]
+    y:  37.6
+    y2: 45.8
+
+  - value: param:gp
+    type: text
+    presets: [rightbar]
+    y:  50.0
+    y2: 58.3
+
+  - value: param:items_sold
+    type: text
+    presets: [rightbar]
+    y:  62.6
+    y2: 70.8
+
+  - value: param:gp_spent
+    type: text
+    presets: [rightbar]
+    y:  75.0
+    y2: 83.4
+
+  - value: param:total_gp
+    type: text
+    presets: [rightbar]
+    y:  87.7
+    y2: 95.8
+
+  - value: param:event
+    type: text
+    presets: [eventinfo]
+    x:   1.1
+    x2: 20.0
+
+  - value: param:eventcode
+    type: text
+    presets: [eventinfo]
+    x:  22.7
+    x2: 33.0
+
+  - value: param:date
+    type: text
+    presets: [eventinfo]
+    x:  35.8
+    x2: 50.3
+
+  - value: param:gm
+    type: text
+    presets: [eventinfo]
+    x:  53.1
+    x2: 77.2
+
+  - value: param:gmid
+    type: text
+    presets: [eventinfo]
+    x:  79.9
+    x2: 99.3
+
+  - value: param:fac1_name
+    type: text
+    presets: [faccol_name, facline1]
+
+  - value: param:fac1_rep_gained
+    type: text
+    presets: [faccol_rep_gained, facline1]
+
+  - value: param:fac1_rep_total
+    type: text
+    presets: [faccol_rep_total, facline1]
+
+  - value: param:fac2_name
+    type: text
+    presets: [faccol_name, facline2]
+
+  - value: param:fac2_rep_gained
+    type: text
+    presets: [faccol_rep_gained, facline2]
+
+  - value: param:fac2_rep_total
+    type: text
+    presets: [faccol_rep_total, facline2]
+
+  - value: param:fac3_name
+    type: text
+    presets: [faccol_name, facline3]
+
+  - value: param:fac3_rep_gained
+    type: text
+    presets: [faccol_rep_gained, facline3]
+
+  - value: param:fac3_rep_total
+    type: text
+    presets: [faccol_rep_total, facline3]
+
+  - type: choice
+    choices: param:strikeout_boons
+    content:
+      1:
+        - type: rectangle
+          presets: [strikeout_boon]
+          canvas: boon1.1
+        - type: rectangle
+          presets: [strikeout_boon]
+          canvas: boon1.2
+      2:
+        - type: rectangle
+          presets: [strikeout_boon]
+          canvas: boon2.1
+        - type: rectangle
+          presets: [strikeout_boon]
+          canvas: boon2.2
+      3:
+        - type: rectangle
+          presets: [strikeout_boon]
+          canvas: boon3.1
+        - type: rectangle
+          presets: [strikeout_boon]
+          canvas: boon3.2
+
+  - choices: param:tier
+    type: choice
+    content:
+      low:
+        - type: rectangle
+          presets: [greyout, max_area]
+          canvas: items_high
+      high:
+        - type: rectangle
+          canvas: items_low
+          presets: [greyout, max_area]
+
+  - value: param:list_items_sold
+    type: multiline
+    presets: [items_purchased_left_col, items_sold_line]
+
+  - value: param:list_items_sold_price
+    type: multiline
+    presets: [items_purchased_right_col, items_sold_line]
+
+  - value: param:items_sold_total_value
+    type: text
+    presets: [items_purchased_right_col, items_sold_line]
+    y:  79.2
+    y2: 96.8
+    align: CM
+
+  - value: param:list_items_bought
+    type: multiline
+    presets: [items_purchased_left_col, items_bought_line]
+
+  - value: param:list_items_bought_price
+    type: multiline
+    presets: [items_purchased_right_col, items_bought_line]
+
+  - value: param:items_bought_total_cost
+    type: text
+    presets: [items_purchased_right_col, items_bought_line]
+    y:  77.0
+    y2: 94.4
+    align: CM
+
+  - value: param:notes
+    type: multiline
+    presets: [commentbox]
+    x2:  49.3
+
+  - value: param:downtime
+    type: multiline
+    presets: [commentbox]
+    x: 50.2


### PR DESCRIPTION
**This is definitely preliminary work, but wanted to submit it in case you hadn't started your own version.**

- Removes parameters and content for fame, which is no longer awarded in season 2
- Removes parameter & content for GP Income, which is now just rolled into GP earned
- Adjusts rightbar & middlebox to new size & offset, and fixes their children accordingly
- Shortens item/condition multiline to 5 lines

I do not own any scenarios for season 2, so this is untested for scenarios so far, but I know it is roughly the same layout for 2-00 at the very least. If nothing I can start checking against them by next week.